### PR TITLE
[raop] - also forward png data to the coverart callback

### DIFF
--- a/src/lib/raop.c
+++ b/src/lib/raop.c
@@ -312,7 +312,7 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response)
 				logger_log(conn->raop->logger, LOGGER_WARNING, "RAOP not initialized at SET_PARAMETER volume");
 			}
 			free(datastr);
-		} else if (!strcmp(content_type, "image/jpeg")) {
+		} else if (!strcmp(content_type, "image/jpeg") || !strcmp(content_type, "image/png")) {
 			logger_log(conn->raop->logger, LOGGER_INFO, "Got image data of %d bytes", datalen);
 			if (conn->raop_rtp) {
 				raop_rtp_set_coverart(conn->raop_rtp, data, datalen);


### PR DESCRIPTION
as the title says. Well this PR does it in a backwards compatible way. Problem now is that the caller needs to determine the type of the coverart data (i do it via detecting the d8ff and d9ff bytes of an jpeg to detect jpeg and assume png in the else case - in kodi).

The right way would be to alter the callback or add a new callback which has data, size and type i guess. Not sure how you want it...