### PR TITLE
[DACP] - add callback for dacp remote control meta data (audio_remote_co...

### DIFF
--- a/include/shairplay/raop.h
+++ b/include/shairplay/raop.h
@@ -40,6 +40,7 @@ struct raop_callbacks_s {
 	void  (*audio_set_volume)(void *cls, void *session, float volume);
 	void  (*audio_set_metadata)(void *cls, void *session, const void *buffer, int buflen);
 	void  (*audio_set_coverart)(void *cls, void *session, const void *buffer, int buflen);
+	void  (*audio_remote_control_id)(void *cls, const char *dacp_id, const char *active_remote_header);
 };
 typedef struct raop_callbacks_s raop_callbacks_t;
 

--- a/src/lib/raop.c
+++ b/src/lib/raop.c
@@ -242,6 +242,19 @@ conn_request(void *ptr, http_request_t *request, http_response_t **response)
 		const char *transport;
 		char buffer[1024];
 		int use_udp;
+		const char *dacp_id;
+		const char *active_remote_header;
+
+		dacp_id = http_request_get_header(request, "DACP-ID");
+		active_remote_header = http_request_get_header(request, "Active-Remote");
+
+		if (dacp_id && active_remote_header) {
+			logger_log(conn->raop->logger, LOGGER_DEBUG, "DACP-ID: %s", dacp_id);
+			logger_log(conn->raop->logger, LOGGER_DEBUG, "Active-Remote: %s", active_remote_header);
+			if (conn->raop_rtp) {
+			    raop_rtp_remote_control_id(conn->raop_rtp, dacp_id, active_remote_header);
+			}
+		}
 
 		transport = http_request_get_header(request, "Transport");
 		assert(transport);

--- a/src/lib/raop_rtp.h
+++ b/src/lib/raop_rtp.h
@@ -33,6 +33,7 @@ void raop_rtp_start(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rp
 void raop_rtp_set_volume(raop_rtp_t *raop_rtp, float volume);
 void raop_rtp_set_metadata(raop_rtp_t *raop_rtp, const char *data, int datalen);
 void raop_rtp_set_coverart(raop_rtp_t *raop_rtp, const char *data, int datalen);
+void raop_rtp_remote_control_id(raop_rtp_t *raop_rtp, const char *dacp_id, const char *active_remote_header);
 void raop_rtp_flush(raop_rtp_t *raop_rtp, int next_seq);
 void raop_rtp_stop(raop_rtp_t *raop_rtp);
 void raop_rtp_destroy(raop_rtp_t *raop_rtp);


### PR DESCRIPTION
...ntrol_id).

This adds a callback for fetching dacp id and active_remote_header. This allows the using app to fetch the correct _dacp._tcp. bonjour announcement and control the airtunes client via DACP as mentioned here:

http://nto.github.io/AirPlay.html#audio-remotecontrol