### PR TITLE
Add support to limit the port range for dynamic binds

### DIFF
--- a/include/shairplay/raop.h
+++ b/include/shairplay/raop.h
@@ -51,7 +51,7 @@ RAOP_API raop_t *raop_init_from_keyfile(int max_clients, raop_callbacks_t *callb
 RAOP_API void raop_set_log_level(raop_t *raop, int level);
 RAOP_API void raop_set_log_callback(raop_t *raop, raop_log_callback_t callback, void *cls);
 
-RAOP_API int raop_start(raop_t *raop, unsigned short *port, const char *hwaddr, int hwaddrlen, const char *password);
+RAOP_API int raop_start(raop_t *raop, unsigned short *port, unsigned short dyn_port_min, unsigned short dyn_port_max, const char *hwaddr, int hwaddrlen, const char *password);
 RAOP_API int raop_is_running(raop_t *raop);
 RAOP_API void raop_stop(raop_t *raop);
 

--- a/src/bindings/python/Shairplay.py
+++ b/src/bindings/python/Shairplay.py
@@ -110,7 +110,7 @@ def InitShairplay(libshairplay):
 	libshairplay.raop_is_running.restype = c_int
 	libshairplay.raop_is_running.argtypes = [c_void_p]
 	libshairplay.raop_start.restype = c_int
-	libshairplay.raop_start.argtypes = [c_void_p, POINTER(c_ushort), POINTER(c_char), c_int, c_char_p]
+	libshairplay.raop_start.argtypes = [c_void_p, POINTER(c_ushort), c_ushort, c_ushort, POINTER(c_char), c_int, c_char_p]
 	libshairplay.raop_stop.restype = None
 	libshairplay.raop_stop.argtypes = [c_void_p]
 	libshairplay.raop_destroy.restype = None
@@ -241,11 +241,11 @@ class RaopService:
 		self.libshairplay.raop_set_log_callback(self.instance, log_callback_ptr, None)
 		self.log_callback = log_callback_ptr
 
-	def start(self, port, hwaddrstr, password=None):
+	def start(self, port, hwaddrstr, password=None, dyn_port_min=0, dyn_port_max=0):
 		port = c_ushort(port)
 		hwaddr = create_string_buffer(hwaddrstr, len(hwaddrstr))
 
-		ret = self.libshairplay.raop_start(self.instance, pointer(port), hwaddr, c_int(len(hwaddr)), password)
+		ret = self.libshairplay.raop_start(self.instance, pointer(port), dyn_port_min, dyn_port_max, hwaddr, c_int(len(hwaddr)), password)
 		if ret < 0:
 			raise RuntimeError("Starting RAOP instance failed")
 		return port.value

--- a/src/bindings/qt4/raopservice.cpp
+++ b/src/bindings/qt4/raopservice.cpp
@@ -206,10 +206,10 @@ bool RaopService::isRunning()
     return (raop_is_running(m_raop) != 0);
 }
 
-bool RaopService::start(quint16 port, const QByteArray & hwaddr)
+bool RaopService::start(quint16 port, const QByteArray & hwaddr, quint16 dyn_min_port, quint16 dyn_max_port)
 {
     int ret;
-    ret = raop_start(m_raop, &port, hwaddr.data(), hwaddr.size(), 0);
+    ret = raop_start(m_raop, &port, dyn_min_port, dyn_max_port, hwaddr.data(), hwaddr.size(), 0);
     if (ret < 0) {
         return false;
     }

--- a/src/bindings/qt4/raopservice.h
+++ b/src/bindings/qt4/raopservice.h
@@ -40,7 +40,7 @@ public:
     bool init(int max_clients, RaopAudioHandler *callbacks);
     void setLogLevel(int level);
     void setLogHandler(RaopLogHandler *logger);
-    bool start(quint16 port, const QByteArray & hwaddr);
+    bool start(quint16 port, const QByteArray & hwaddr, quint16 dyn_min_port=0, quint16 dyn_max_port=0);
     bool isRunning();
     void stop();
 

--- a/src/lib/httpd.c
+++ b/src/lib/httpd.c
@@ -368,13 +368,13 @@ httpd_start(httpd_t *httpd, unsigned short *port)
 		return 0;
 	}
 
-	httpd->server_fd4 = netutils_init_socket(port, 0, 0);
+	httpd->server_fd4 = netutils_init_socket(port, 0, 0, 0, 0);
 	if (httpd->server_fd4 == -1) {
 		logger_log(httpd->logger, LOGGER_ERR, "Error initialising socket %d", SOCKET_GET_ERROR());
 		MUTEX_UNLOCK(httpd->run_mutex);
 		return -1;
 	}
-	httpd->server_fd6 = netutils_init_socket(port, 1, 0);
+	httpd->server_fd6 = netutils_init_socket(port, 1, 0, 0, 0);
 	if (httpd->server_fd6 == -1) {
 		logger_log(httpd->logger, LOGGER_WARNING, "Error initialising IPv6 socket %d", SOCKET_GET_ERROR());
 		logger_log(httpd->logger, LOGGER_WARNING, "Continuing without IPv6 support");

--- a/src/lib/netutils.h
+++ b/src/lib/netutils.h
@@ -18,7 +18,7 @@
 int netutils_init();
 void netutils_cleanup();
 
-int netutils_init_socket(unsigned short *port, int use_ipv6, int use_udp);
+int netutils_init_socket(unsigned short *port, int use_ipv6, int use_udp, unsigned short dyn_port_min, unsigned short dyn_port_max);
 unsigned char *netutils_get_address(void *sockaddr, int *length);
 int netutils_parse_address(int family, const char *src, void *dst, int dstlen);
 

--- a/src/lib/raop_rtp.c
+++ b/src/lib/raop_rtp.c
@@ -179,7 +179,8 @@ raop_rtp_destroy(raop_rtp_t *raop_rtp)
 }
 
 static int
-raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp)
+raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp,
+      unsigned short dyn_port_min, unsigned short dyn_port_max)
 {
 	int csock = -1, tsock = -1, dsock = -1;
 	unsigned short cport = 0, tport = 0, dport = 0;
@@ -187,13 +188,13 @@ raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp)
 	assert(raop_rtp);
 
 	if (use_udp) {
-		csock = netutils_init_socket(&cport, use_ipv6, use_udp);
-		tsock = netutils_init_socket(&tport, use_ipv6, use_udp);
+		csock = netutils_init_socket(&cport, use_ipv6, use_udp, dyn_port_min, dyn_port_max);
+		tsock = netutils_init_socket(&tport, use_ipv6, use_udp, dyn_port_min, dyn_port_max);
 		if (csock == -1 || tsock == -1) {
 			goto sockets_cleanup;
 		}
 	}
-	dsock = netutils_init_socket(&dport, use_ipv6, use_udp);
+	dsock = netutils_init_socket(&dport, use_ipv6, use_udp, dyn_port_min, dyn_port_max);
 	if (dsock == -1) {
 		goto sockets_cleanup;
 	}
@@ -601,6 +602,7 @@ raop_rtp_thread_tcp(void *arg)
 
 void
 raop_rtp_start(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rport, unsigned short timing_rport,
+               unsigned short dyn_port_min, unsigned short dyn_port_max,
                unsigned short *control_lport, unsigned short *timing_lport, unsigned short *data_lport)
 {
 	int use_ipv6 = 0;
@@ -619,7 +621,7 @@ raop_rtp_start(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rport, 
 	if (raop_rtp->remote_saddr.ss_family == AF_INET6) {
 		use_ipv6 = 1;
 	}
-	if (raop_rtp_init_sockets(raop_rtp, use_ipv6, use_udp) < 0) {
+	if (raop_rtp_init_sockets(raop_rtp, use_ipv6, use_udp, dyn_port_min, dyn_port_max) < 0) {
 		logger_log(raop_rtp->logger, LOGGER_INFO, "Initializing sockets failed");
 		MUTEX_UNLOCK(raop_rtp->run_mutex);
 		return;

--- a/src/lib/raop_rtp.h
+++ b/src/lib/raop_rtp.h
@@ -29,6 +29,7 @@ raop_rtp_t *raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, const c
                           const char *rtpmap, const char *fmtp,
                           const unsigned char *aeskey, const unsigned char *aesiv);
 void raop_rtp_start(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rport, unsigned short timing_rport,
+                    unsigned short dyn_port_min, unsigned short dyn_port_max,
                     unsigned short *control_lport, unsigned short *timing_lport, unsigned short *data_lport);
 void raop_rtp_set_volume(raop_rtp_t *raop_rtp, float volume);
 void raop_rtp_set_metadata(raop_rtp_t *raop_rtp, const char *data, int datalen);


### PR DESCRIPTION
This feature is required to work in an environment with at least somewhat sane firewall rules.

Usage:

    ./shairplay .... --dyn_port_min=5000 --dyn_port_max=5010

This will ensure that the UDP/TCP ports dynamically bound will be betewen 5000 and 5010 (inclusive).

Binding changes have not been tested (not even compiled).