### PR TITLE
[configure] - only check for dns_sd.h in case libdl was not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ LT_LIB_DLLOAD
 
 # Checks for header files.
 AC_HEADER_STDC
-if test yes = "$libltdl_cv_func_dlopen" || test yes = "$libltdl_cv_lib_dl_dlopen"
+if test no = "$libltdl_cv_func_dlopen" && test no = "$libltdl_cv_lib_dl_dlopen"
 then
   AC_CHECK_HEADERS([dns_sd.h], [],
                    [AC_MSG_ERROR([Could not find dns_sd.h header, please install libavahi-compat-libdnssd-dev or equivalent.])])


### PR DESCRIPTION
the code in dnssd.c suggests that we only need dns_sd.h when libdl was not found. The configure check for dns_sd.h checked the opposite which broke builds were dns_sd.h is not available but libdl is available.