### PR TITLE
Fix new iOS versons can't find airplay issue

### DIFF
--- a/src/lib/dnssd.c
+++ b/src/lib/dnssd.c
@@ -300,6 +300,7 @@ dnssd_register_airplay(dnssd_t *dnssd, const char *name, unsigned short port, co
 	dnssd->TXTRecordSetValue(&txtRecord, "deviceid", strlen(deviceid), deviceid);
 	dnssd->TXTRecordSetValue(&txtRecord, "features", strlen("0x5A7FFFF7,0xE"), "0x5A7FFFF7,0xE");
 	dnssd->TXTRecordSetValue(&txtRecord, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
+	dnssd->TXTRecordSetValue(&txtRecord, "srcvers", strlen(GLOBAL_VERSION), GLOBAL_VERSION);
 	dnssd->TXTRecordSetValue(&txtRecord, "vv", 1, "2");
 
 	/* Register the service */


### PR DESCRIPTION
This dnssd.c file seems to be missing one line of code, which cause newest iOS and macOS version can't discover airplay server.