### PR TITLE
Underline that airport.key exists in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Start the server with ```shairplay```, if you are connected to a Wi-Fi the
 server should show as an AirPort Express on your iOS devices and Mac OS X
 computers in the same network.
 
-Notice that you need to have the airport.key file in your working directory when
+Notice that you need to have the [airport.key](airport.key) file in your working directory when
 starting the shairplay service. It is not included in the binary for possible
 legal reasons.
 


### PR DESCRIPTION
Add a link to airport.key to underline that it's available in repo despite not being included in binary.

I mistakenly thought it meant it wasn't available in the repo and only discovered it after searching through issues