### PR TITLE
Add missing LGPL and copyright headers (7 files created by juvoh)

### DIFF
--- a/include/shairplay/dnssd.h
+++ b/include/shairplay/dnssd.h
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2012  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef DNSSD_H
 #define DNSSD_H
 

--- a/include/shairplay/raop.h
+++ b/include/shairplay/raop.h
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2012-2015  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef RAOP_H
 #define RAOP_H
 

--- a/src/lib/dnssdint.h
+++ b/src/lib/dnssdint.h
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2012  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef DNSSDINT_H
 #define DNSSDINT_H
 

--- a/src/lib/fairplay.h
+++ b/src/lib/fairplay.h
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2018  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef FAIRPLAY_H
 #define FAIRPLAY_H
 

--- a/src/lib/fairplay_dummy.c
+++ b/src/lib/fairplay_dummy.c
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2018  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #include <stdlib.h>
 
 #include "fairplay.h"

--- a/src/lib/fairplay_playfair.c
+++ b/src/lib/fairplay_playfair.c
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2018  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/src/lib/global.h
+++ b/src/lib/global.h
@@ -1,3 +1,17 @@
+/**
+ *  Copyright (C) 2012  Juho Vähä-Herttua
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef GLOBAL_H
 #define GLOBAL_H
 


### PR DESCRIPTION
This LGPL code is reused in active GPLv3 projects [RPiPlay](https://github.com/FD-/RPiPlay) and [UxPlay](https://github.com/FDH2/UxPlay) and perhaps many others.

Its important that the LGPL license is in order.   

7 files authored by juvoh (**raop.h dnssd.h** in include/shairplay/ ; **dnssdint.h, global.h, fairplay.h, fairplay_dummy.c, fairplay_playfair.c** in src/lib/) are missing their LGPL and copyright headers.

This PR corrects that, with appropriate dates taken from the commit history.

Please commit this pull request (hoping you eventually see it) and make this valuable code LGPL-clean! (apart from GPLv3 playfair, of course)